### PR TITLE
adding AR github issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ar_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/ar_bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Automated Review Bug report
+about: Create a report when a failure occurs in main branch
+title: ''
+labels: 'Automated_Review'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Failed Jenkins Job Information:**
+The name of the job that failed, job build number, and code snippit of the failure.
+
+**Attachments**
+Attach the Jenkins job log as a .txt file and any other relevant information.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Creating GitHub Issues template for AR main breaks to be utilized by the SIG members that own AR.